### PR TITLE
Fix stray dash warning

### DIFF
--- a/plugins/theme.engine.plg
+++ b/plugins/theme.engine.plg
@@ -61,7 +61,7 @@ The 'post-install' script
 <FILE Run="/bin/bash">
 <INLINE>
 <![CDATA[
-if cat /usr/local/emhttp/plugins/dynamix/include/DefaultPageLayout.php | grep '<?php include '\''\/usr\/local\/emhttp\/plugins\/theme\.engine\/include\.php'\''; ?>' > /dev/null;
+if cat /usr/local/emhttp/plugins/dynamix/include/DefaultPageLayout.php | grep '<?php include '\''/usr/local/emhttp/plugins/theme\.engine/include\.php'\''; ?>' > /dev/null;
 then
 echo "Looks good... continuing... "
 else


### PR DESCRIPTION
Fixes the grep warning: "stray \ before /".
https://forums.unraid.net/topic/87126-plugin-theme-engine-a-webgui-styler/?do=findComment&comment=1173150