### PR TITLE
fix: deprecation warnings for string interpolation

### DIFF
--- a/source/theme.engine/usr/local/emhttp/plugins/theme.engine/ThemeEngine.page
+++ b/source/theme.engine/usr/local/emhttp/plugins/theme.engine/ThemeEngine.page
@@ -403,12 +403,12 @@ Custom color base0F:
 
 
 Custom styling (advanced):
-: <textarea id="themecss" spellcheck="false" rows="10"><?php $filename="/boot/config/plugins/theme.engine/themes/${ThemeEngine['themename']}-${display['theme']}.css";if(file_exists($filename)){echo file_get_contents($filename);} ?></textarea>
+: <textarea id="themecss" spellcheck="false" rows="10"><?php $filename="/boot/config/plugins/theme.engine/themes/{$ThemeEngine['themename']}-{$display['theme']}.css";if(file_exists($filename)){echo file_get_contents($filename);} ?></textarea>
 </div>
 </div>
 
 &nbsp;
-: <input type="checkbox" id="exportcheckbox"> Export to Saved Themes <span id="themespan"><?php if(is_file("/boot/config/plugins/theme.engine/themes/${ThemeEngine['themename']}-${display['theme']}.cfg")) { echo "(this will overwrite ${ThemeEngine['themename']}-${display['theme']}!)"; } ?></span>
+: <input type="checkbox" id="exportcheckbox"> Export to Saved Themes <span id="themespan"><?php if(is_file("/boot/config/plugins/theme.engine/themes/{$ThemeEngine['themename']}-{$display['theme']}.cfg")) { echo "(this will overwrite {$ThemeEngine['themename']}-{$display['theme']}!)"; } ?></span>
 
 <input type="submit" name="#default" value="Clear Settings" onclick="disableOnSubmit();" style="color:#fff;background-color:#890008">
 : <input type="submit" name="#apply" id="applysettings" value="Apply" disabled><input type="button" id="done" value="Done" onclick="donezo()"> <a id="saveToFile" class="advanced">Download current confirguration as Zip File</a> <span class="advanced">(Apply changes first)</span>

--- a/source/theme.engine/usr/local/emhttp/plugins/theme.engine/include.php
+++ b/source/theme.engine/usr/local/emhttp/plugins/theme.engine/include.php
@@ -136,8 +136,8 @@ img{-webkit-filter:grayscale(<?=$grayscale?>%);filter:grayscale(<?=$grayscale?>%
 
 
 if ($ThemeEngine['customstyle'] == "1") {
-	if ( is_file("/boot/config/plugins/theme.engine/themes/${ThemeEngine['themename']}-${display['theme']}.css") ) {
-		include "/boot/config/plugins/theme.engine/themes/${ThemeEngine['themename']}-${display['theme']}.css";
+	if ( is_file("/boot/config/plugins/theme.engine/themes/{$ThemeEngine['themename']}-{$display['theme']}.css") ) {
+		include "/boot/config/plugins/theme.engine/themes/{$ThemeEngine['themename']}-{$display['theme']}.css";
 	}
 
 }


### PR DESCRIPTION
In preparing for #6 I noticed there were some deprecation warnings due to Unraid's webgui updating PHP versions.

<img width="1050" alt="Screenshot 2025-04-02 at 13 14 55" src="https://github.com/user-attachments/assets/44ed0619-3fa6-404a-bd25-3fe903a1dc74" />

This PR should fix those.